### PR TITLE
Relax InfluxDB client version specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 dist: trusty
 language: ruby
 rvm:
-- 2.4.1
-- 2.3.4
+- 2.5
+- 2.4
+- 2.3
 before_install:
 - gem install bundler -v 1.15.1

--- a/telegraf.gemspec
+++ b/telegraf.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'influxdb', '~> 0.3.15'
+  spec.add_dependency 'influxdb', '~> 0.3'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
Hello :)

This specification allows to use newer versions of InfluxDB client, but until 1.0.

I've also added Ruby 2.5.

Hope this helps.