### PR TITLE
Fix name of default connection var

### DIFF
--- a/lib/telegraf/agent.rb
+++ b/lib/telegraf/agent.rb
@@ -2,7 +2,7 @@
 
 module Telegraf
   class Agent
-    DEFAULT_URI = 'udp://localhost:8094'
+    DEFAULT_CONNECTION = 'udp://localhost:8094'
 
     attr_reader :uri
     attr_reader :logger

--- a/spec/telegraf_spec.rb
+++ b/spec/telegraf_spec.rb
@@ -100,4 +100,24 @@ RSpec.describe Telegraf do
       server.close
     end
   end
+
+  it 'Default server' do
+    Dir.mktmpdir do |_dir|
+      server = UDPSocket.new
+      server.bind 'localhost', 8094
+
+      agent = Telegraf::Agent.new
+
+      agent.write([
+                    {series: 'demo', tags: {a: 1, b: 2}, values: {a: 1, b: 2.1}},
+                    {series: 'demo', tags: {a: '1', b: 2}, values: {a: 6, b: 2.5}}
+                  ])
+
+      recv = server.read_nonblock(4096)
+
+      expect(recv).to eq "demo,a=1,b=2 a=1i,b=2.1\ndemo,a=1,b=2 a=6i,b=2.5"
+
+      server.close
+    end
+  end
 end


### PR DESCRIPTION
- Problem
When try to instance Telegraf::Agent.new we get error.

```
2.5.1 :001 > telegraf = Telegraf::Agent.new
Traceback (most recent call last):
        2: from (irb):1
        1: from (irb):1:in `new'
NameError (uninitialized constant Telegraf::Agent::DEFAULT_CONNECTION)
```

The name of the constant was `DEFAULT_URI` and on constructor signature was `DEFAULT_CONNECTION`.

- Solution
We changed `DEFAULT_URI` to `DEFAULT_CONNECTION` to fix the method
initialize

- Issue: [#3](https://github.com/jgraichen/telegraf-ruby/issues/3)