### PR TITLE
Fix typo in config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class MyApplication > ::Rails::Application
 
   # Additionally the application is instrumented to tag events with
   # controller and action as well as to collect app, database and view timings
-  config.telegraf.instrumenation = true
+  config.telegraf.instrumentation = true
 end
 ```
 

--- a/lib/telegraf/railtie.rb
+++ b/lib/telegraf/railtie.rb
@@ -51,7 +51,7 @@ module Telegraf
     config.telegraf.rack.tags = {}
 
     # Install request instrumentation
-    config.telegraf.instrumenation = true
+    config.telegraf.instrumentation = true
 
     initializer 'telegraf.agent' do |app|
       app.config.telegraf.agent ||= begin
@@ -72,7 +72,7 @@ module Telegraf
     end
 
     initializer 'telegraf.instrumentation' do |app|
-      next unless app.config.telegraf.instrumenation
+      next unless app.config.telegraf.instrumentation
 
       ActiveSupport::Notifications.subscribe(
         'process_action.action_controller'


### PR DESCRIPTION
Technically, this is a breaking change, but since the option was added only yesterday, I think we're fine fixing this in a patch release.