### PR TITLE
Collect metrics from Sidekiq when installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rubocop', '~> 0.80.0'
 
 gem 'rack'
 gem 'railties'
+gem 'sidekiq', '~> 6.0'
 
 # Specify your gem's dependencies in telegraf.gemspec
 gemspec

--- a/gemfiles/rack_2.0.gemfile
+++ b/gemfiles/rack_2.0.gemfile
@@ -9,5 +9,6 @@ gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
 gem "rack", "~> 2.0.0"
 gem "railties"
+gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/gemfiles/rack_2.1.gemfile
+++ b/gemfiles/rack_2.1.gemfile
@@ -9,5 +9,6 @@ gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
 gem "rack", "~> 2.1.0"
 gem "railties"
+gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/gemfiles/rack_2.2.gemfile
+++ b/gemfiles/rack_2.2.gemfile
@@ -9,5 +9,6 @@ gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
 gem "rack", "~> 2.2.0"
 gem "railties"
+gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -9,5 +9,6 @@ gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
 gem "rack"
 gem "railties", "~> 5.0.0"
+gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -9,5 +9,6 @@ gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
 gem "rack"
 gem "railties", "~> 5.1.0"
+gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -9,5 +9,6 @@ gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
 gem "rack"
 gem "railties", "~> 5.2.0"
+gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -9,5 +9,6 @@ gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
 gem "rack"
 gem "railties", "~> 6.0.0"
+gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/lib/telegraf/sidekiq.rb
+++ b/lib/telegraf/sidekiq.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rack'
+
+module Telegraf
+  module Sidekiq
+    # Telegraf::Sidekiq::Middleware
+    #
+    # This Sidekiq middleware collects queue metrics and sends them to telegraf.
+    #
+    #
+    # Tags:
+    #
+    # * `type`:
+    #     One of "job" or "scheduled_job".
+    #
+    # * `queue`:
+    #     The queue this job landed on.
+    #
+    # * `worker`:
+    #     The name of the worker class that was executed.
+    #
+    # * `errors`:
+    #     Whether or not this job errored.
+    #
+    # * `retry`:
+    #     Whether or not this execution was a retry of a previously failed one.
+    #
+    #
+    # Values:
+    #
+    # * `app_ms`:
+    #     Total worker processing time.
+    #
+    # * `queue_ms`:
+    #     How long did this job wait in the queue before being processed?
+    #     Only present for "normal" (async) jobs (with tag `type` of "job").
+    #
+    class Middleware
+      def initialize(agent:, series: 'sidekiq', tags: {})
+        @agent = agent
+        @series = series.to_s.freeze
+        @tags = tags.freeze
+      end
+
+      def call(worker, job, queue)
+        job_start = ::Time.now.utc
+
+        tags = {
+          **@tags,
+          type: 'job',
+          errors: true,
+          retry: job.key?('retried_at'),
+          queue: queue,
+          worker: worker.class.name
+        }
+
+        values = {
+          retry_count: job['retry_count']
+        }.compact
+
+        # The "enqueued_at" key is not present for scheduled jobs.
+        # See https://github.com/mperham/sidekiq/wiki/Job-Format.
+        if job.key?('enqueued_at')
+          enqueued_at = ::Time.at(job['enqueued_at'].to_f).utc
+          values[:queue_ms] = (job_start - enqueued_at) * 1000 # milliseconds
+        end
+
+        # The "at" key is only present for scheduled jobs.
+        tags[:type] = 'scheduled_job' if job.key?('at')
+
+        begin
+          yield
+
+          # If we get here, this was a successful execution
+          tags[:errors] = false
+        ensure
+          job_stop = ::Time.now.utc
+
+          values[:app_ms] = (job_stop - job_start) * 1000 # milliseconds
+
+          @agent.write(
+            @series, tags: tags, values: values
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/telegraf/sidekiq_spec.rb
+++ b/spec/telegraf/sidekiq_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'telegraf/sidekiq'
+require 'tmpdir'
+
+require 'sidekiq'
+require 'sidekiq/testing'
+
+class HardWorker
+  include Sidekiq::Worker
+
+  def perform(_message)
+    # noop
+  end
+end
+
+class FailWorker
+  include Sidekiq::Worker
+
+  def perform(message)
+    raise message
+  end
+end
+
+RSpec.describe Telegraf::Sidekiq::Middleware do
+  subject(:work!) do
+    queue!
+    Sidekiq::Worker.drain_all
+  end
+
+  let(:queue!) { HardWorker.perform_async('test') }
+  let(:socket) { UNIXServer.new "#{tmpdir}/sock" }
+  let(:agent) { Telegraf::Agent.new "unix:#{tmpdir}/sock" }
+  let(:args) { {} }
+
+  before do
+    Sidekiq::Testing.server_middleware do |chain|
+      chain.add Telegraf::Sidekiq::Middleware, agent: agent, **args
+    end
+
+    Sidekiq::Worker.clear_all
+  end
+
+  context 'successful async execution' do
+    it 'type=job,errors=false app_ms,queue_ms' do
+      work!
+
+      expect(last_point.series).to eq 'sidekiq'
+      expect(last_point.tags).to include 'type' => 'job', 'worker' => 'HardWorker', 'queue' => 'default', 'errors' => 'false', 'retry' => 'false'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/, 'queue_ms' => /^\d+\.\d+$/
+    end
+  end
+
+  context 'successful scheduled execution' do
+    let(:queue!) { HardWorker.perform_at(Time.now.utc + 20, 'test') }
+
+    it 'type=scheduled_job,errors=false app_ms' do
+      work!
+
+      expect(last_point.series).to eq 'sidekiq'
+      expect(last_point.tags).to include 'type' => 'scheduled_job', 'worker' => 'HardWorker', 'queue' => 'default', 'errors' => 'false', 'retry' => 'false'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/
+    end
+  end
+
+  context 'with error' do
+    let(:queue!) { FailWorker.perform_async('test') }
+
+    it 'type=job,errors=true app_ms,queue_ms' do
+      work! rescue nil
+
+      expect(last_point.series).to eq 'sidekiq'
+      expect(last_point.tags).to include 'type' => 'job', 'worker' => 'FailWorker', 'queue' => 'default', 'errors' => 'true', 'retry' => 'false'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/, 'queue_ms' => /^\d+\.\d+$/
+    end
+  end
+
+  context 'with custom series name' do
+    let(:args) { {series: 'background'} }
+
+    it 'uses the custom series' do
+      work!
+
+      expect(last_point.series).to eq 'background'
+      expect(last_point.tags).to include 'type' => 'job', 'worker' => 'HardWorker', 'queue' => 'default', 'errors' => 'false', 'retry' => 'false'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/, 'queue_ms' => /^\d+\.\d+$/
+    end
+  end
+
+  context 'with extra tags' do
+    let(:args) { {tags: {my: 'tag'}} }
+
+    it 'adds the tag to the standard tags' do
+      work!
+
+      expect(last_point.series).to eq 'sidekiq'
+      expect(last_point.tags).to include 'type' => 'job', 'worker' => 'HardWorker', 'queue' => 'default', 'errors' => 'false', 'retry' => 'false', 'my' => 'tag'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/, 'queue_ms' => /^\d+\.\d+$/
+    end
+  end
+end


### PR DESCRIPTION
Following in the footsteps of #5, this automatically collects metrics from Sidekiq workers, as previously tested in one of our internal applications.