### PR TITLE
Fix incorrect URL in gemspec

### DIFF
--- a/telegraf.gemspec
+++ b/telegraf.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Metric Reporter to local telegraf agent'
   spec.description   = 'Metric Reporter to local telegraf agent'
-  spec.homepage      = 'https://github.com/jgraichen/ruby-telegraf'
+  spec.homepage      = 'https://github.com/jgraichen/telegraf-ruby'
   spec.license       = 'LGPLv3'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
The homepage URL in the gemspec (and thus on rubygems.org) pointed to `jgraichen/ruby-telegraf`, but the actual repository name is `jgraichen/telegraf-ruby`.