### PR TITLE
Collect events from ActiveJob when installed

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,25 +2,25 @@
 
 appraise "rails-5.0" do
   group :test do
-    gem "railties", "~> 5.0.0"
+    gem "rails", "~> 5.0.0"
   end
 end
 
 appraise "rails-5.1" do
   group :test do
-    gem "railties", "~> 5.1.0"
+    gem "rails", "~> 5.1.0"
   end
 end
 
 appraise "rails-5.2" do
   group :test do
-    gem "railties", "~> 5.2.0"
+    gem "rails", "~> 5.2.0"
   end
 end
 
 appraise "rails-6.0" do
   group :test do
-    gem "railties", "~> 6.0.0"
+    gem "rails", "~> 6.0.0"
   end
 end
 

--- a/Appraisals
+++ b/Appraisals
@@ -1,29 +1,43 @@
 # frozen_string_literal: true
 
 appraise "rails-5.0" do
-  gem "railties", "~> 5.0.0"
+  group :test do
+    gem "railties", "~> 5.0.0"
+  end
 end
 
 appraise "rails-5.1" do
-  gem "railties", "~> 5.1.0"
+  group :test do
+    gem "railties", "~> 5.1.0"
+  end
 end
 
 appraise "rails-5.2" do
-  gem "railties", "~> 5.2.0"
+  group :test do
+    gem "railties", "~> 5.2.0"
+  end
 end
 
 appraise "rails-6.0" do
-  gem "railties", "~> 6.0.0"
+  group :test do
+    gem "railties", "~> 6.0.0"
+  end
 end
 
 appraise "rack-2.0" do
-  gem "rack", "~> 2.0.0"
+  group :test do
+    gem "rack", "~> 2.0.0"
+  end
 end
 
 appraise "rack-2.1" do
-  gem "rack", "~> 2.1.0"
+  group :test do
+    gem "rack", "~> 2.1.0"
+  end
 end
 
 appraise "rack-2.2" do
-  gem "rack", "~> 2.2.0"
+  group :test do
+    gem "rack", "~> 2.2.0"
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,15 +2,20 @@
 
 source 'https://rubygems.org'
 
-gem 'appraisal'
-gem 'rake-release', '~> 1.2'
+# Specify your gem's dependencies in telegraf.gemspec
+gemspec
+
 gem 'rake'
 gem 'rspec', '~> 3.8'
 gem 'rubocop', '~> 0.80.0'
 
-gem 'rack'
-gem 'railties'
-gem 'sidekiq', '~> 6.0'
+group :test do
+  gem 'rack'
+  gem 'railties'
+  gem 'sidekiq', '~> 6.0'
+end
 
-# Specify your gem's dependencies in telegraf.gemspec
-gemspec
+group :development do
+  gem 'appraisal'
+  gem 'rake-release', '~> 1.2'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rubocop', '~> 0.80.0'
 
 group :test do
   gem 'rack'
-  gem 'railties'
+  gem 'rails'
   gem 'sidekiq', '~> 6.0'
 end
 

--- a/gemfiles/rack_2.0.gemfile
+++ b/gemfiles/rack_2.0.gemfile
@@ -8,7 +8,7 @@ gem "rubocop", "~> 0.80.0"
 
 group :test do
   gem "rack", "~> 2.0.0"
-  gem "railties"
+  gem "rails"
   gem "sidekiq", "~> 6.0"
 end
 

--- a/gemfiles/rack_2.0.gemfile
+++ b/gemfiles/rack_2.0.gemfile
@@ -2,13 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake-release", "~> 1.2"
 gem "rake"
 gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
-gem "rack", "~> 2.0.0"
-gem "railties"
-gem "sidekiq", "~> 6.0"
+
+group :test do
+  gem "rack", "~> 2.0.0"
+  gem "railties"
+  gem "sidekiq", "~> 6.0"
+end
+
+group :development do
+  gem "appraisal"
+  gem "rake-release", "~> 1.2"
+end
 
 gemspec path: "../"

--- a/gemfiles/rack_2.1.gemfile
+++ b/gemfiles/rack_2.1.gemfile
@@ -8,7 +8,7 @@ gem "rubocop", "~> 0.80.0"
 
 group :test do
   gem "rack", "~> 2.1.0"
-  gem "railties"
+  gem "rails"
   gem "sidekiq", "~> 6.0"
 end
 

--- a/gemfiles/rack_2.1.gemfile
+++ b/gemfiles/rack_2.1.gemfile
@@ -2,13 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake-release", "~> 1.2"
 gem "rake"
 gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
-gem "rack", "~> 2.1.0"
-gem "railties"
-gem "sidekiq", "~> 6.0"
+
+group :test do
+  gem "rack", "~> 2.1.0"
+  gem "railties"
+  gem "sidekiq", "~> 6.0"
+end
+
+group :development do
+  gem "appraisal"
+  gem "rake-release", "~> 1.2"
+end
 
 gemspec path: "../"

--- a/gemfiles/rack_2.2.gemfile
+++ b/gemfiles/rack_2.2.gemfile
@@ -2,13 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake-release", "~> 1.2"
 gem "rake"
 gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
-gem "rack", "~> 2.2.0"
-gem "railties"
-gem "sidekiq", "~> 6.0"
+
+group :test do
+  gem "rack", "~> 2.2.0"
+  gem "railties"
+  gem "sidekiq", "~> 6.0"
+end
+
+group :development do
+  gem "appraisal"
+  gem "rake-release", "~> 1.2"
+end
 
 gemspec path: "../"

--- a/gemfiles/rack_2.2.gemfile
+++ b/gemfiles/rack_2.2.gemfile
@@ -8,7 +8,7 @@ gem "rubocop", "~> 0.80.0"
 
 group :test do
   gem "rack", "~> 2.2.0"
-  gem "railties"
+  gem "rails"
   gem "sidekiq", "~> 6.0"
 end
 

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,13 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake-release", "~> 1.2"
 gem "rake"
 gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
-gem "rack"
-gem "railties", "~> 5.0.0"
-gem "sidekiq", "~> 6.0"
+
+group :test do
+  gem "rack"
+  gem "railties", "~> 5.0.0"
+  gem "sidekiq", "~> 6.0"
+end
+
+group :development do
+  gem "appraisal"
+  gem "rake-release", "~> 1.2"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -8,7 +8,7 @@ gem "rubocop", "~> 0.80.0"
 
 group :test do
   gem "rack"
-  gem "railties", "~> 5.0.0"
+  gem "rails", "~> 5.0.0"
   gem "sidekiq", "~> 6.0"
 end
 

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,13 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake-release", "~> 1.2"
 gem "rake"
 gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
-gem "rack"
-gem "railties", "~> 5.1.0"
-gem "sidekiq", "~> 6.0"
+
+group :test do
+  gem "rack"
+  gem "railties", "~> 5.1.0"
+  gem "sidekiq", "~> 6.0"
+end
+
+group :development do
+  gem "appraisal"
+  gem "rake-release", "~> 1.2"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -8,7 +8,7 @@ gem "rubocop", "~> 0.80.0"
 
 group :test do
   gem "rack"
-  gem "railties", "~> 5.1.0"
+  gem "rails", "~> 5.1.0"
   gem "sidekiq", "~> 6.0"
 end
 

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,13 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake-release", "~> 1.2"
 gem "rake"
 gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
-gem "rack"
-gem "railties", "~> 5.2.0"
-gem "sidekiq", "~> 6.0"
+
+group :test do
+  gem "rack"
+  gem "railties", "~> 5.2.0"
+  gem "sidekiq", "~> 6.0"
+end
+
+group :development do
+  gem "appraisal"
+  gem "rake-release", "~> 1.2"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -8,7 +8,7 @@ gem "rubocop", "~> 0.80.0"
 
 group :test do
   gem "rack"
-  gem "railties", "~> 5.2.0"
+  gem "rails", "~> 5.2.0"
   gem "sidekiq", "~> 6.0"
 end
 

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,13 +2,19 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake-release", "~> 1.2"
 gem "rake"
 gem "rspec", "~> 3.8"
 gem "rubocop", "~> 0.80.0"
-gem "rack"
-gem "railties", "~> 6.0.0"
-gem "sidekiq", "~> 6.0"
+
+group :test do
+  gem "rack"
+  gem "railties", "~> 6.0.0"
+  gem "sidekiq", "~> 6.0"
+end
+
+group :development do
+  gem "appraisal"
+  gem "rake-release", "~> 1.2"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -8,7 +8,7 @@ gem "rubocop", "~> 0.80.0"
 
 group :test do
   gem "rack"
-  gem "railties", "~> 6.0.0"
+  gem "rails", "~> 6.0.0"
   gem "sidekiq", "~> 6.0"
 end
 

--- a/lib/telegraf/active_job.rb
+++ b/lib/telegraf/active_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Telegraf
+  # Telegraf::ActiveJob
+  #
+  # This class collects ActiveJob queue metrics and sends them to telegraf.
+  #
+  #
+  # Tags:
+  #
+  # * `queue`:
+  #     The queue this job landed on.
+  #
+  # * `job`:
+  #     The name of the job class that was executed.
+  #
+  # * `errors`:
+  #     Whether or not this job errored.
+  #
+  #
+  # Values:
+  #
+  # * `app_ms`:
+  #     Total job processing time.
+  #
+  class ActiveJob
+    def initialize(agent:, series: 'active_job', tags: {})
+      @agent = agent
+      @series = series.to_s.freeze
+      @tags = tags.freeze
+    end
+
+    def call(_name, start, finish, _id, payload)
+      job = payload[:job]
+
+      @agent.write(
+        @series,
+        tags: {
+          **@tags,
+          job: job.class.name,
+          queue: job.queue_name,
+          errors: payload.key?(:exception_object)
+        },
+        values: {
+          app_ms: ((finish - start) * 1000.0) # milliseconds
+        }
+      )
+    end
+  end
+end

--- a/spec/telegraf/active_job_spec.rb
+++ b/spec/telegraf/active_job_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'telegraf/active_job'
+require 'tmpdir'
+
+require 'active_job'
+
+class HardJob < ActiveJob::Base
+  def perform(_message)
+    # noop
+  end
+end
+
+class FailJob < ActiveJob::Base
+  def perform(message)
+    raise message
+  end
+end
+
+RSpec.describe Telegraf::ActiveJob do
+  subject(:work!) { HardJob.perform_now 'test' }
+
+  let(:socket) { UNIXServer.new "#{tmpdir}/sock" }
+  let(:agent) { Telegraf::Agent.new "unix:#{tmpdir}/sock" }
+  let(:args) { {} }
+
+  before do
+    ActiveSupport::Notifications.subscribe(
+      'perform.active_job',
+      Telegraf::ActiveJob.new(agent: agent, **args)
+    )
+
+    ActiveJob::Base.logger = Logger.new(IO::NULL)
+  end
+
+  context 'successful async execution' do
+    it 'job=HardJob,queue=default,errors=false app_ms' do
+      work!
+
+      expect(last_point.series).to eq 'active_job'
+      expect(last_point.tags).to include 'job' => 'HardJob', 'queue' => 'default', 'errors' => 'false'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/
+    end
+  end
+
+  context 'with error' do
+    subject(:work!) { FailJob.perform_now 'test' }
+
+    it 'job=HardJob,queue=default,errors=true app_ms' do
+      work! rescue nil
+
+      expect(last_point.series).to eq 'active_job'
+      expect(last_point.tags).to include 'job' => 'FailJob', 'queue' => 'default', 'errors' => 'true'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/
+    end
+  end
+
+  context 'with custom series name' do
+    let(:args) { {series: 'background'} }
+
+    it 'uses the custom series' do
+      work!
+
+      expect(last_point.series).to eq 'background'
+      expect(last_point.tags).to include 'job' => 'HardJob', 'queue' => 'default', 'errors' => 'false'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/
+    end
+  end
+
+  context 'with extra tags' do
+    let(:args) { {tags: {my: 'tag'}} }
+
+    it 'adds the tag to the standard tags' do
+      work!
+
+      expect(last_point.series).to eq 'active_job'
+      expect(last_point.tags).to include 'job' => 'HardJob', 'queue' => 'default', 'errors' => 'false', 'my' => 'tag'
+      expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/
+    end
+  end
+end


### PR DESCRIPTION
This automatically collects events from ActiveJob, based on the Sidekiq adapter implemented in #8 and inspired by how [mnemosyne-ruby](https://github.com/mnemosyne-mon/mnemosyne-ruby/) collected metrics for this library.