### PR TITLE
Fix inconsistent port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ require "telegraf/rails"
 
 class MyApplication > ::Rails::Application
   # Configure receiver
-  config.telegraf.connect = "udp://localhost:9084"
+  config.telegraf.connect = "udp://localhost:8094"
 
   # Global tags added to all events. These will override
   # any local tag with the same name.


### PR DESCRIPTION
Everywhere else had 8094 except for the Rails example, which had 9084. I'm embarrassed at how long it took me to track this down.