### PR TITLE
Fix Ruby 3 keyword arg deprecation

### DIFF
--- a/lib/telegraf/sidekiq.rb
+++ b/lib/telegraf/sidekiq.rb
@@ -37,10 +37,10 @@ module Telegraf
     #     Only present for "normal" (async) jobs (with tag `type` of "job").
     #
     class Middleware
-      def initialize(agent:, series: 'sidekiq', tags: {})
-        @agent = agent
-        @series = series.to_s.freeze
-        @tags = tags.freeze
+      def initialize(options)
+        @agent = options.fetch(:agent)
+        @series = options.fetch(:series, 'sidekiq').to_s.freeze
+        @tags = options.fetch(:tags) { {} }.freeze
       end
 
       def call(worker, job, queue)


### PR DESCRIPTION
Fixes `Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call` deprecation warnings in 2.7.

Since we can't change how Sidekiq passes the middleware args back to the initializer, I think downgrading to options/fetch is the only option.