### PR TITLE
Extract request handler info for Grape APIs

### DIFF
--- a/lib/telegraf/grape.rb
+++ b/lib/telegraf/grape.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Telegraf
+  # Telegraf::Grape
+  #
+  # This class extends requests metrics with details for Grape API endpoints.
+  #
+  #
+  # Tags:
+  #
+  # * `controller`:
+  #     The Grape endpoint class.
+  #
+  # * `instance`:
+  #     The Grape endpoint class.
+  #
+  # * `format`:
+  #     Grape's internal identifier for the response format.
+  #
+  class Grape
+    def call(_name, _start, _finish, _id, payload)
+      point = payload[:env][::Telegraf::Rack::FIELD_NAME]
+      return unless point
+
+      endpoint = payload[:endpoint]
+      return unless endpoint
+
+      point.tags[:controller] = endpoint.options[:for].to_s
+      point.tags[:instance] = point.tags[:controller]
+      point.tags[:format] = payload[:env]['api.format']
+    end
+  end
+end


### PR DESCRIPTION
`grape` is a common gem for defining API endpoints. We used to get this
instrumentation via the processing pipeline in `mnemosyne-server`, but
this has been disabled in favor of explicit Telegraf metrics as the
app's responsibility. Grape support had not been added here since then.