### PR TITLE
Fix Runtime error for concurrent serialization

### DIFF
--- a/lib/telegraf/agent.rb
+++ b/lib/telegraf/agent.rb
@@ -24,7 +24,7 @@ module Telegraf
       tags = tags.merge(@tags) unless @tags.empty?
 
       if values
-        data = [{series: series || data.to_s, tags: tags, values: values}]
+        data = [{series: series || data.to_s, tags: tags, values: values.dup}]
       end
 
       socket = connect @uri


### PR DESCRIPTION
Recently, an error in this library was discovered that caused a Ruby exception when serializing point values after the request finished. In conjunction with hijacked TCP connections (e.g., with an upgrade to a WebSocket connection), additional data might be added even when the HTTP response was rendered. In this case, adding a new data point failed with `RuntimeError: can't add a new key into hash during iteration` as caused by https://github.com/jgraichen/telegraf-ruby/blob/1e4f9d0eaa66f73356bc923fcddc612eb210a462/lib/telegraf/railtie.rb#L109