### PR TITLE
Allow to exclude paths from Rack

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This gem include a Rails plugin and middlewares / adapters for Rack, ActiveJob a
 require "telegraf/rack"
 
 agent = ::Telegraf::Agent.new
-use ::Telegraf::Rack.new(series: 'rack', agent: agent, tags: {global: 'tag'})
+use ::Telegraf::Rack.new(series: 'rack', agent: agent, tags: {global: 'tag'}, exclude_paths: ['/health', '/metrics']
 ```
 
 See middleware [class documentation](lib/telegraf/rack.rb) for more details.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ class MyApplication > ::Rails::Application
   # By default the Rack middleware to collect events is installed
   config.telegraf.rack.enabled = true
   config.telegraf.rack.series = "requests"
+  config.telegraf.rack.exclude_paths = []
   config.telegraf.rack.tags = {}
 
   # These are the default settings when ActiveJob is detected
@@ -107,6 +108,9 @@ class MyApplication > ::Rails::Application
   config.telegraf.instrumentation = true
 end
 ```
+
+To exclude to exclude certain paths use `config.telegraf.rack.exclude_paths` where the array of values like `['/health', '/metrics']` will be matched against `request.path`. The default is `[]`.
+
 
 Received event example:
 

--- a/lib/telegraf/rack.rb
+++ b/lib/telegraf/rack.rb
@@ -51,7 +51,7 @@ module Telegraf
     # rubocop:disable Lint/StructNewOverride
     Point = Struct.new(:tags, :values)
     # rubocop:enable Lint/StructNewOverride
-
+    # rubocop:disable Metrics/ParameterLists
     def initialize(app, agent:, series: 'rack', tags: {}, exclude_paths: [], logger: nil)
       @app = app
       @tags = tags.freeze
@@ -60,6 +60,7 @@ module Telegraf
       @series = series.to_s.freeze
       @logger = logger
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def call(env)
       if (request_start = extract_request_start(env))

--- a/lib/telegraf/rack.rb
+++ b/lib/telegraf/rack.rb
@@ -116,7 +116,7 @@ module Telegraf
     end
 
     def skip_agent?(env)
-      @exclude_paths.include?(env['PATH_INFO']
+      @exclude_paths.include?(env['PATH_INFO'])
     end
   end
 end

--- a/lib/telegraf/rack.rb
+++ b/lib/telegraf/rack.rb
@@ -52,7 +52,7 @@ module Telegraf
     Point = Struct.new(:tags, :values)
     # rubocop:enable Lint/StructNewOverride
 
-    def initialize(app, agent:, series: 'rack', tags: {}, exclude_paths:, logger: nil)
+    def initialize(app, agent:, series: 'rack', tags: {}, exclude_paths: [], logger: nil)
       @app = app
       @tags = tags.freeze
       @exclude_paths = exclude_paths.freeze

--- a/lib/telegraf/railtie.rb
+++ b/lib/telegraf/railtie.rb
@@ -53,6 +53,7 @@ module Telegraf
     config.telegraf.rack = ::ActiveSupport::OrderedOptions.new
     config.telegraf.rack.enabled = true
     config.telegraf.rack.series = 'requests'
+    config.telegraf.rack.exclude_paths = []
     config.telegraf.rack.tags = {}
 
     # Install request instrumentation
@@ -89,6 +90,7 @@ module Telegraf
         agent: app.config.telegraf.agent,
         series: app.config.telegraf.rack.series,
         tags: app.config.telegraf.rack.tags,
+        exclude_paths: app.config.telegraf.rack.exclude_paths,
         logger: Rails.logger
     end
 


### PR DESCRIPTION
Main reason we need to exclude paths is the crazy amount of health checks or metrics flooding telegraf.
Option for `exclude_paths` will prevent reporting on that endpoints