### PR TITLE
feat: Add before_send filter to all plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
           - rack_2.0.gemfile
           - rack_2.1.gemfile
           - rack_2.2.gemfile
+          - sidekiq_6.gemfile
+          - sidekiq_7.gemfile
         exclude:
           - ruby: "3.2"
             gemfile: rails_5.2.gemfile
@@ -63,7 +65,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: '3.3'
           bundler-cache: true
 
       - run: bundle exec rubocop --parallel --color

--- a/Appraisals
+++ b/Appraisals
@@ -41,3 +41,15 @@ appraise 'rack-2.2' do
     gem 'rack', '~> 2.2.0'
   end
 end
+
+appraise 'sidekiq-6' do
+  group :test do
+    gem 'sidekiq', '~> 6.0'
+  end
+end
+
+appraise 'sidekiq-7' do
+  group :test do
+    gem 'sidekiq', '~> 7.0'
+  end
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New standalone Influx line protocol serializer
+- `before_send` filter option for agent and all plugins (#27)
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'rubocop-config', github: 'jgraichen/rubocop-config', ref: 'v11'
 group :test do
   gem 'rack'
   gem 'rails'
-  gem 'sidekiq', '~> 7.1', '>= 7.1.3'
+  gem 'sidekiq'
 end
 
 group :development do

--- a/gemfiles/rack_2.0.gemfile
+++ b/gemfiles/rack_2.0.gemfile
@@ -4,13 +4,12 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rspec", "~> 3.8"
-gem "rubocop", "~> 1.7"
-gem "rubocop-rspec", "~> 1.41"
+gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack", "~> 2.0.0"
   gem "rails"
-  gem "sidekiq", "~> 6.0"
+  gem "sidekiq", "~> 7.1", ">= 7.1.3"
 end
 
 group :development do

--- a/gemfiles/rack_2.0.gemfile
+++ b/gemfiles/rack_2.0.gemfile
@@ -9,7 +9,7 @@ gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 group :test do
   gem "rack", "~> 2.0.0"
   gem "rails"
-  gem "sidekiq", "~> 7.1", ">= 7.1.3"
+  gem "sidekiq"
 end
 
 group :development do

--- a/gemfiles/rack_2.1.gemfile
+++ b/gemfiles/rack_2.1.gemfile
@@ -4,13 +4,12 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rspec", "~> 3.8"
-gem "rubocop", "~> 1.7"
-gem "rubocop-rspec", "~> 1.41"
+gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack", "~> 2.1.0"
   gem "rails"
-  gem "sidekiq", "~> 6.0"
+  gem "sidekiq", "~> 7.1", ">= 7.1.3"
 end
 
 group :development do

--- a/gemfiles/rack_2.1.gemfile
+++ b/gemfiles/rack_2.1.gemfile
@@ -9,7 +9,7 @@ gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 group :test do
   gem "rack", "~> 2.1.0"
   gem "rails"
-  gem "sidekiq", "~> 7.1", ">= 7.1.3"
+  gem "sidekiq"
 end
 
 group :development do

--- a/gemfiles/rack_2.2.gemfile
+++ b/gemfiles/rack_2.2.gemfile
@@ -4,13 +4,12 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rspec", "~> 3.8"
-gem "rubocop", "~> 1.7"
-gem "rubocop-rspec", "~> 1.41"
+gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack", "~> 2.2.0"
   gem "rails"
-  gem "sidekiq", "~> 6.0"
+  gem "sidekiq", "~> 7.1", ">= 7.1.3"
 end
 
 group :development do

--- a/gemfiles/rack_2.2.gemfile
+++ b/gemfiles/rack_2.2.gemfile
@@ -9,7 +9,7 @@ gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 group :test do
   gem "rack", "~> 2.2.0"
   gem "rails"
-  gem "sidekiq", "~> 7.1", ">= 7.1.3"
+  gem "sidekiq"
 end
 
 group :development do

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -4,13 +4,12 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rspec", "~> 3.8"
-gem "rubocop", "~> 1.7"
-gem "rubocop-rspec", "~> 1.41"
+gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack"
   gem "rails", "~> 5.2.0"
-  gem "sidekiq", "~> 6.0"
+  gem "sidekiq", "~> 7.1", ">= 7.1.3"
 end
 
 group :development do

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -4,13 +4,12 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rspec", "~> 3.8"
-gem "rubocop", "~> 1.7"
-gem "rubocop-rspec", "~> 1.41"
+gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack"
   gem "rails", "~> 6.0.0"
-  gem "sidekiq", "~> 6.0"
+  gem "sidekiq", "~> 7.1", ">= 7.1.3"
 end
 
 group :development do

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -9,7 +9,7 @@ gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 group :test do
   gem "rack"
   gem "rails", "~> 6.0.0"
-  gem "sidekiq", "~> 7.1", ">= 7.1.3"
+  gem "sidekiq"
 end
 
 group :development do

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -9,7 +9,7 @@ gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 group :test do
   gem "rack"
   gem "rails", "~> 6.1.0"
-  gem "sidekiq", "~> 7.1", ">= 7.1.3"
+  gem "sidekiq"
 end
 
 group :development do

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -4,13 +4,12 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rspec", "~> 3.8"
-gem "rubocop", "~> 1.7"
-gem "rubocop-rspec", "~> 1.41"
+gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack"
   gem "rails", "~> 6.1.0"
-  gem "sidekiq", "~> 6.0"
+  gem "sidekiq", "~> 7.1", ">= 7.1.3"
 end
 
 group :development do

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,13 +4,12 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rspec", "~> 3.8"
-gem "rubocop", "~> 1.7"
-gem "rubocop-rspec", "~> 1.41"
+gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack"
   gem "rails", "~> 7.0.0"
-  gem "sidekiq", "~> 6.0"
+  gem "sidekiq", "~> 7.1", ">= 7.1.3"
 end
 
 group :development do

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -9,7 +9,7 @@ gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 group :test do
   gem "rack"
   gem "rails", "~> 7.0.0"
-  gem "sidekiq", "~> 7.1", ">= 7.1.3"
+  gem "sidekiq"
 end
 
 group :development do

--- a/gemfiles/sidekiq_6.gemfile
+++ b/gemfiles/sidekiq_6.gemfile
@@ -8,8 +8,8 @@ gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack"
-  gem "rails", "~> 5.2.0"
-  gem "sidekiq"
+  gem "rails"
+  gem "sidekiq", "~> 6.0"
 end
 
 group :development do

--- a/gemfiles/sidekiq_7.gemfile
+++ b/gemfiles/sidekiq_7.gemfile
@@ -8,8 +8,8 @@ gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v11"
 
 group :test do
   gem "rack"
-  gem "rails", "~> 5.2.0"
-  gem "sidekiq"
+  gem "rails"
+  gem "sidekiq", "~> 7.0"
 end
 
 group :development do

--- a/lib/telegraf.rb
+++ b/lib/telegraf.rb
@@ -4,4 +4,5 @@ require 'telegraf/version'
 
 module Telegraf
   require 'telegraf/agent'
+  require 'telegraf/plugin'
 end

--- a/lib/telegraf/plugin.rb
+++ b/lib/telegraf/plugin.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rack'
+
+module Telegraf
+  module Plugin
+    # Warning: `:values` member overrides `Struct#values` and it may be
+    # unexpected, but nothing we can change here as this is an import public API
+    # right now.
+    #
+    # rubocop:disable Lint/StructNewOverride
+    Point = Struct.new(:tags, :values, keyword_init: true) do
+      def initialize(tags: {}, values: {})
+        super
+      end
+    end
+    # rubocop:enable Lint/StructNewOverride
+
+    def initialize(agent:, series:, tags: {}, before_send: nil, **)
+      @agent = agent
+
+      @tags = tags.freeze
+      @series = String(series).freeze
+      @before_send = before_send
+    end
+
+    def _write(point, before_send_kwargs: {})
+      if @before_send
+        point = @before_send.call(point, **before_send_kwargs)
+        return unless point
+      end
+
+      @agent.write(@series, tags: point.tags, values: point.values)
+    end
+  end
+end

--- a/spec/telegraf/agent_spec.rb
+++ b/spec/telegraf/agent_spec.rb
@@ -16,9 +16,41 @@ RSpec.describe Telegraf::Agent do
 
       it 'merges tags into event' do
         # Write app tag here too to ensure it is overwritten by global tags
-        agent.write('series', tags: {app: 'no', field: 'yes'}, values: {a: 1})
+        agent.write!('series', tags: {app: 'no', field: 'yes'}, values: {a: 1})
         expect(socket_read).to eq 'series,app=test,field=yes,tagged=yes a=1i'
       end
+    end
+  end
+
+  describe '@before_send' do
+    let(:kwargs) { {before_send: before_send} }
+    let(:before_send) do
+      lambda {|data|
+        data.delete_if {|line| line[:tags].key?(:drop) }
+        data
+      }
+    end
+
+    it 'drops all points' do
+      agent.write!('series', tags: {drop: 1}, values: {a: 1})
+      expect { socket_read }.to raise_error(EOFError)
+    end
+
+    it 'drops matching points' do
+      agent.write!('series', tags: {drop: 1}, values: {a: 1})
+      agent.write!('series', tags: {field: 'yes'}, values: {a: 1})
+
+      expect { socket_read }.to raise_error(EOFError)
+      expect(socket_read).to eq 'series,field=yes a=1i'
+    end
+
+    it 'drops matching points in bulk mode' do
+      agent.write!([
+        {series: 'series', tags: {drop: 1}, values: {a: 1}},
+        {series: 'series', tags: {field: 'yes'}, values: {a: 1}},
+      ])
+
+      expect(socket_read).to eq 'series,field=yes a=1i'
     end
   end
 end

--- a/spec/telegraf/agent_spec.rb
+++ b/spec/telegraf/agent_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Telegraf::Agent do
       }
     end
 
-    it 'drops all points' do
+    it 'drops all points when all points match' do
       agent.write!('series', tags: {drop: 1}, values: {a: 1})
       expect { socket_read }.to raise_error(EOFError)
     end

--- a/spec/telegraf/rack_spec.rb
+++ b/spec/telegraf/rack_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Telegraf::Rack do
         }
       end
 
-      it('drops matching points') do
+      it 'drops matching points' do
         mock.request('GET', '/', {})
         mock.request('GET', '/healthcheck', {})
 

--- a/spec/telegraf/sidekiq_spec.rb
+++ b/spec/telegraf/sidekiq_spec.rb
@@ -135,4 +135,23 @@ RSpec.describe Telegraf::Sidekiq::Middleware do
       expect(last_point.values).to match 'app_ms' => /^\d+\.\d+$/, 'queue_ms' => /^\d+\.\d+$/
     end
   end
+
+  context 'with before_send filter' do
+    let(:args) { {before_send: before_send} }
+
+    context 'excluding specific worker' do
+      let(:before_send) do
+        lambda {|point, worker:, **|
+          return if worker.instance_of?(HardWorker)
+
+          point
+        }
+      end
+
+      it('drops matching points') do
+        work!
+        expect(last_points.size).to eq 0
+      end
+    end
+  end
 end

--- a/spec/telegraf/sidekiq_spec.rb
+++ b/spec/telegraf/sidekiq_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Telegraf::Sidekiq::Middleware do
         }
       end
 
-      it('drops matching points') do
+      it 'drops matching points' do
         work!
         expect(last_points.size).to eq 0
       end


### PR DESCRIPTION
All plugins (e.g. rack, sidekiq) and the agent offer a `before_send:`
initializer argument now that takes a lambda to filter points before
writing. The lambda must return the (modified) points that will be
written. If nothing is returned, nothing will be written. This way,
points can be modified (e.g. tags added/removed) or filtered away.

Example:

    Telegraf::Rack.new(
      before_send: lambda do |point, request:, **|
        # Do not emit metrics for this secret path
        return if %r{^/secret}.match?(request.path)

        # Never collect controller details (make debugging hard)
        point.tags.delete(:controller)
        point
      end,
    )

See the individual plugins for which arguments are given to the lambda.

The agents before_send filter will always only received the a list of
raw data points as the write! method takes it too. No additional
arguments will be passed on.

For Rails, one can set before_send filter via the following config keys:

  * config.telegraf.before_send
  * config.telegraf.rack.before_send
  * config.telegraf.grape.before_send
  * config.telegraf.active_job.before_send
  * config.telegraf.sidekiq.before_send