### PR TITLE
Allow integer timestamps for `X-Request-Start`

### DIFF
--- a/lib/telegraf/rack.rb
+++ b/lib/telegraf/rack.rb
@@ -38,7 +38,8 @@ module Telegraf
   # * `queue_ms`:
   #     Queue time calculated from a `X-Request-Start` header if present. The
   #     header is expected to be formatted like this `t=<timestamp>` and
-  #     contain a floating point timestamp in seconds.
+  #     contain either a floating point timestamp in seconds, or an integer
+  #     timestamp in milliseconds or microseconds or nanoseconds.
   #
   class Rack
     include ::Telegraf::Plugin
@@ -100,7 +101,8 @@ module Telegraf
       return unless env.key?('HTTP_X_REQUEST_START')
 
       if (m = HEADER_REGEX.match(env['HTTP_X_REQUEST_START']))
-        ::Time.at(m[1].to_f).utc
+        value = m[2].nil? ? "#{m[1][0, 10]}.#{m[1][10, 13]}" : m[1]
+        ::Time.at(value.to_f).utc
       end
     rescue FloatDomainError
       # Ignore obscure floats in Time.at (e.g. infinity)

--- a/spec/telegraf/rack_spec.rb
+++ b/spec/telegraf/rack_spec.rb
@@ -47,9 +47,19 @@ RSpec.describe Telegraf::Rack do
     end
   end
 
-  context 'with X-Request-Start' do
+  context 'with X-Request-Start floating point timestamp in seconds' do
     it 'includes queue_ms value' do
       mock.request('GET', '/', {'HTTP_X_REQUEST_START' => "t=#{Time.now.utc.to_f}"})
+
+      expect(last_points.size).to eq 1
+      expect(last_point.values.keys).to include 'queue_ms'
+      expect(last_point.values['queue_ms']).to match(/\A\d+\.\d+\z/)
+    end
+  end
+
+  context 'with X-Request-Start integer timestamp in microseconds' do
+    it 'includes queue_ms value' do
+      mock.request('GET', '/', {'HTTP_X_REQUEST_START' => "t=#{Time.now.utc.to_f.to_s.delete('.')}"})
 
       expect(last_points.size).to eq 1
       expect(last_point.values.keys).to include 'queue_ms'


### PR DESCRIPTION
There's no standard for the value of the `X-Request-Start` header, unfortunately, e.g., Nginx `${msec}` returns time in 10.3 millisecond format, Apache returns time as microseconds without decimal places, and so does Caddy's `{time.now.unix_ms}`.  This PR handles the situation where the timestamp is an integer (stolen from [here](https://github.com/discourse/prometheus_exporter/blob/main/lib/prometheus_exporter/middleware.rb#L124)).